### PR TITLE
Update Home page to include buttons for all components from Gallery

### DIFF
--- a/testFabric/HomePage.tsx
+++ b/testFabric/HomePage.tsx
@@ -48,6 +48,10 @@ const createStyles = () =>
       paddingRight: 10,
       paddingLeft: 10,
     },
+    disabledButton: {
+      color: '#007AFF',
+      opacity: 0.5,
+    }
   });
 
   const HomeContainer = (props: {heading: string; children: React.ReactNode}) => {
@@ -89,11 +93,15 @@ const createStyles = () =>
             flexDirection: 'row',
             marginRight: 5,
             marginBottom: 5,
+            opacity: RNGalleryList[props.index].component ? 1 : 0.5,
           },
         ]}
         onPress={() => {
-          props.navigation.push(RNGalleryList[props.index].key)
-        }}>
+          if (RNGalleryList[props.index].component) {
+            props.navigation.push(RNGalleryList[props.index].key)
+          }
+        }}
+        disabled={!RNGalleryList[props.index].component}>
         <Text style={styles.icon}>{RNGalleryList[props.index].icon}</Text>
         <Text style={[styles.text, {paddingRight: 10}]}>
           {RNGalleryList[props.index].key}
@@ -117,17 +125,55 @@ const createStyles = () =>
   };
 
 const RenderPageContent = ({navigation}) => {
-  var components = [];
+  var basicInput = [];
+  var dateAndTime = [];
+  var dialogsAndFlyouts = [];
+  var layout = [];
+  var text = [];
+  var statusAndInfo = [];
+  var media = [];
   for (var i = 0; i < RNGalleryList.length; i++) {
-    components.push(i);
+    if (RNGalleryList[i].type === 'Basic Input') {
+      basicInput.push(i);
+    } else if (RNGalleryList[i].type === 'Date and Time') {
+      dateAndTime.push(i);
+    } else if (RNGalleryList[i].type === 'Dialogs and Flyouts') {
+      dialogsAndFlyouts.push(i);
+    } else if (RNGalleryList[i].type === 'Layout') {
+      layout.push(i);
+    } else if (RNGalleryList[i].type === 'Text') {
+      text.push(i);
+    } else if (RNGalleryList[i].type === 'Status and Info') {
+      statusAndInfo.push(i);
+    } else if (RNGalleryList[i].type === 'Media') {
+      media.push(i);
+    }
   }
   return (
     <ScrollView>
-      <HomeContainer heading="Components">
-        {RenderHomeComponentTiles(components, navigation)}
+      <HomeContainer heading="Basic Input">
+        {RenderHomeComponentTiles(basicInput, navigation)}
+      </HomeContainer>
+      <HomeContainer heading="Date and Time">
+        {RenderHomeComponentTiles(dateAndTime, navigation)}
+      </HomeContainer>
+      <HomeContainer heading="Dialogs and Flyouts">
+        {RenderHomeComponentTiles(dialogsAndFlyouts, navigation)}
+      </HomeContainer>
+      <HomeContainer heading="Layout">
+        {RenderHomeComponentTiles(layout, navigation)}
+      </HomeContainer>
+      <HomeContainer heading="Text">
+        {RenderHomeComponentTiles(text, navigation)}
+      </HomeContainer>
+      <HomeContainer heading="Status and Info">
+        {RenderHomeComponentTiles(statusAndInfo, navigation)}
+      </HomeContainer>
+      <HomeContainer heading="Media">
+        {RenderHomeComponentTiles(media, navigation)}
       </HomeContainer>
     </ScrollView>
-  )
+  );
 
 }
 

--- a/testFabric/RNGalleryList.ts
+++ b/testFabric/RNGalleryList.ts
@@ -1,6 +1,6 @@
 'use strict';
 import React from 'react';
-// import {HomePage} from './HomePage';
+import {HomePage} from './HomePage';
 import { ActivityIndicatorExample } from './examples/ActivityIndicatorExamplePage';
 import {TextExamplePage} from './examples/TextExamplePage';
 import {TextInputExamplePage} from './examples/TextInputExamplePage';
@@ -11,17 +11,68 @@ import {ScrollViewExamplePage} from './examples/ScrollViewExample';
 
 interface IRNGalleryExample {
   key: string;
-  component: React.ElementType;
+  component?: React.ElementType;
   icon: string;
   type: string;
 }
 
 export const RNGalleryList: Array<IRNGalleryExample> = [
   {
+    key: 'Home',
+    component: HomePage,
+    icon: '\uE80F',
+    type: '',
+  },
+  {
     key: 'ActivityIndicator',
     component: ActivityIndicatorExample,
-    icon: '\uEB9F',
-    type: 'Media',
+    icon: '\uE815',
+    type: 'Basic Input',
+  },
+  {
+    key: 'Settings',
+    icon: '\uE713',
+    type: '',
+  },
+  {
+    key: 'Button',
+    icon: '\uE815',
+    type: 'Basic Input',
+  },
+  {
+    key: 'CheckBox',
+    icon: '\uE73A',
+    type: 'Basic Input',
+  },
+  {
+    key: 'Config',
+    icon: '\uE753',
+    type: 'Status and Info',
+  },
+  {
+    key: 'DatePicker',
+    icon: '\uE787',
+    type: 'Date and Time',
+  },
+  {
+    key: 'DeviceInfo',
+    icon: '\uE703',
+    type: 'Status and Info',
+  },
+  {
+    key: 'Expander',
+    icon: '\uE8C4',
+    type: 'Layout',
+  },
+  {
+    key: 'FlatList ',
+    icon: '\uE8A4',
+    type: 'Layout',
+  },
+  {
+    key: 'Flyout',
+    icon: '\uE75A',
+    type: 'Dialogs and Flyouts',
   },
   {
     key: 'Image',
@@ -30,10 +81,55 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     type: 'Media',
   },
   {
+    key: 'Permissions',
+    icon: '\uED2C',
+    type: 'Status and Info',
+  },
+  {
+    key: 'Picker',
+    icon: '\uE7B8',
+    type: 'Basic Input',
+  },
+  {
+    key: 'Popup',
+    icon: '\uE75A',
+    type: 'Layout',
+  },
+  {
+    key: 'Pressable',
+    icon: '\uE815',
+    type: 'Basic Input',
+  },
+  {
+    key: 'Print',
+    icon: '\uE749',
+    type: 'Media',
+  },
+  {
+    key: 'ProgressView',
+    icon: '\uF16A',
+    type: 'Basic Input',
+  },
+  {
     key: 'ScrollView',
     component: ScrollViewExamplePage,
     icon: '\uEC8F',
     type: 'Layout',
+  },
+  {
+    key: 'SensitiveInfo',
+    icon: '\uE72E',
+    type: 'Status and Info',
+  },
+  {
+    key: 'Slider',
+    icon: '\uE9E9',
+    type: 'Basic Input',
+  },
+  {
+    key: 'Sketch',
+    icon: '\uE790',
+    type: 'Media',
   },
   {
     key: 'Switch',
@@ -54,9 +150,60 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     type: 'Text',
   },
   {
+    key: 'TimePicker',
+    icon: '\uE823',
+    type: 'Date and Time',
+  },
+  {
+    key: 'TextToSpeech',
+    icon: '\uEC43',
+    type: 'Media',
+  },
+  {
+    key: 'TouchableHighlight',
+    icon: '\uEDA4',
+    type: 'Basic Input',
+  },
+  {
+    key: 'TouchableOpacity',
+    icon: '\uEDA4',
+    type: 'Basic Input',
+  },
+  {
+    key: 'TouchableWithoutFeedback',
+    icon: '\uEDA4',
+    type: 'Basic Input',
+  },
+  {
+    key: 'TrackPlayer',
+    icon: '\uEC4F',
+    type: 'Media',
+  },
+  {
     key: 'View',
     component: ViewExamplePage,
     icon: '\uECA5',
+    type: 'Layout',
+  },
+  {
+    key: 'WebView',
+    component: null,
+    icon: '\uE774',
+    type: 'Media',
+  },
+  {
+    key: 'WindowsHello',
+    icon: '\uE890',
+    type: 'Status and Info',
+  },
+  {
+    key: 'VirtualizedList',
+    icon: '\uE8A4',
+    type: 'Layout',
+  },
+  {
+    key: 'Xaml',
+    icon: '\uE70F',
     type: 'Layout',
   },
 ];


### PR DESCRIPTION
## Description
This PR updates the home page of the test Gallery Fabric app to include buttons for all the components from the current Gallery app, and match that format visually. The buttons for components that have not been implemented yet have been greyed out to show that they are not implemented currently. As time progresses and more components and support are added to Fabric, more components will be available on the app, so it can be used as a progress measure.
 
### Why

Resolves https://github.com/microsoft/react-native-gallery/issues/396

### What

Updated Home page Javascript code to reformat component buttons.

## Screenshots
Before:
![image](https://github.com/Yajur-Grover/react-native-gallery/assets/157416350/a48de03e-b2fc-4d89-9feb-875c5e56e02d)

After:
![image](https://github.com/Yajur-Grover/react-native-gallery/assets/157416350/9ce7835a-922b-4f07-87f2-ba51f91f3c67)
