### PR TITLE
Fix instances of text and background color incorrectly/not using PlatformColor values on New Arch

### DIFF
--- a/NewArch/src/HomePage.tsx
+++ b/NewArch/src/HomePage.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   ScrollView,
   Image,
+  PlatformColor,
 } from 'react-native';
 import React from 'react';
 import {useTheme, useIsFocused} from './Navigation';
@@ -23,7 +24,7 @@ const createStyles = () =>
       alignSelf: 'stretch',
       height: '100%',
       alignContent: 'flex-start',
-      backgroundColor: 'rgba(216, 216, 216, 0.5)',
+      backgroundColor: PlatformColor('Background'),
     },
     scrollView: {
       paddingRight: 20,

--- a/NewArch/src/Navigation.tsx
+++ b/NewArch/src/Navigation.tsx
@@ -2,6 +2,7 @@ import React, {useState, useEffect} from 'react';
 import {
   Animated,
   Easing,
+  PlatformColor,
   Pressable,
   View,
   useAnimatedValue,
@@ -232,7 +233,7 @@ const DrawerNavigator = ({drawerContent, defaultStatus, children} : DrawerNaviga
                 style={{opacity: fadeAnim}}>
                 <Pressable
                   style={{
-                    backgroundColor: 'rgba(216, 216, 216, 0.5)',
+                    backgroundColor: PlatformColor('Background'),
                     maxWidth: DEFAULT_DRAWER_WIDTH,
                     height: '100%',
                     width: '100%'}}

--- a/NewArch/src/components/Code.tsx
+++ b/NewArch/src/components/Code.tsx
@@ -5,7 +5,7 @@ import {PlatformColor, StyleSheet, Text, View} from 'react-native';
 import {ThemeContext} from '../themes/Theme';
 
 const darkColors = {
-  background: 'transparent',
+  background: PlatformColor('Background'),
   text: PlatformColor('TextFillColorPrimary'),
   comment: '#6a9955',
   keyword: '#c586c0',
@@ -19,7 +19,7 @@ const darkColors = {
 };
 
 const lightColors = {
-  background: 'transparent',
+  background: PlatformColor('Background'),
   text: PlatformColor('TextFillColorPrimary'),
   comment: '#000000',
   keyword: '#FF0000',

--- a/NewArch/src/components/ControlItem.tsx
+++ b/NewArch/src/components/ControlItem.tsx
@@ -14,7 +14,7 @@ import type {IRNGalleryExample} from '../RNGalleryList';
 const createStyles = (colors: any, isHovered: boolean, isPressing: boolean) =>
   StyleSheet.create({
     controlItem: {
-      backgroundColor: '#fdfdfd',
+      backgroundColor: PlatformColor('Background'),
       borderColor: isPressing
         ? '#5f5f5f'
         : isHovered

--- a/NewArch/src/components/Example.tsx
+++ b/NewArch/src/components/Example.tsx
@@ -10,7 +10,7 @@ const createStyles = (colors: any) =>
       marginTop: 30,
       marginBottom: 10,
       fontSize: 20,
-      color: colors.text,
+      color: PlatformColor('TextControlForeground'),
     },
     box: {
       borderRadius: 8,
@@ -19,14 +19,14 @@ const createStyles = (colors: any) =>
     },
     exampleContainer: {
       padding: 15,
-      backgroundColor: PlatformColor('SolidBackgroundFillColorSecondaryBrush'),
+      backgroundColor: PlatformColor('Background'),
     },
     codeContainer: {
       borderWidth: 0,
       borderTopWidth: 1,
       borderColor: colors.border,
       padding: 12,
-      backgroundColor: PlatformColor('CardBackgroundFillColorDefaultBrush'),
+      backgroundColor: PlatformColor('Background'),
     },
   });
 

--- a/NewArch/src/components/LinkTile.tsx
+++ b/NewArch/src/components/LinkTile.tsx
@@ -1,4 +1,4 @@
-import {StyleSheet, Text, View} from 'react-native';
+import {PlatformColor, StyleSheet, Text, View} from 'react-native';
 import React from 'react';
 import {useTheme} from '../Navigation';
 // import {HyperlinkButton} from 'react-native-xaml';
@@ -15,7 +15,7 @@ const createStyles = (colors: any) =>
     hyperlinkTileTitle: {
       marginBottom: 10,
       fontSize: 20,
-      color: colors.text,
+      color: PlatformColor('TextControlForeground'),
     },
   });
 

--- a/NewArch/src/components/Page.tsx
+++ b/NewArch/src/components/Page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ScrollView, StyleSheet, Text, View} from 'react-native';
+import {PlatformColor, ScrollView, StyleSheet, Text, View} from 'react-native';
 import {NativeControlBadge} from './NativeControlBadge';
 import {CoreComponentBadge} from './CoreComponentBadge';
 import {CommunityModuleBadge} from './CommunityModuleBadge';
@@ -13,6 +13,7 @@ const styles = StyleSheet.create({
     height: '100%',
   },
   title: {
+    color: PlatformColor('TextControlForeground'),
     fontWeight: '600',
     fontSize: 28,
   },
@@ -93,7 +94,7 @@ export function Page(props: {
   //const {colors} = useTheme();
   //const isScreenFocused = useIsFocused();
   return (
-    <ScreenWrapper style={styles.container}>
+    <ScreenWrapper>
       <View style={styles.titlePane}>
         <Text accessible accessibilityRole={'header'} style={styles.title}>
           {props.title}
@@ -105,7 +106,7 @@ export function Page(props: {
       </View>
 
       {props.description && (
-        <Text style={[styles.description, {color: '#505050'}]}>
+        <Text style={[styles.description, {color: PlatformColor('TextControlForeground')}]}>
           {props.description}
         </Text>
       )}

--- a/NewArch/src/components/ScreenWrapper.tsx
+++ b/NewArch/src/components/ScreenWrapper.tsx
@@ -16,9 +16,10 @@ const createStyles = () =>
       flexDirection: 'row',
       width: '100%',
       height: '100%',
+      backgroundColor: PlatformColor('Background'),
     },
     navBar: {
-      backgroundColor: 'rgba(233, 233, 233, 0.47)',
+      backgroundColor: PlatformColor('Background'),
       width: 48,
       height: '100%',
       paddingBottom: 20,

--- a/NewArch/src/components/TileGallery.tsx
+++ b/NewArch/src/components/TileGallery.tsx
@@ -19,9 +19,7 @@ const createStyles = (isHovered: boolean, _isPressing: boolean) =>
       // https://github.com/microsoft/WinUI-Gallery/blob/c3cf8db5607c71f5df51fd4eb45d0ce6e932d338/WinUIGallery/Controls/HeaderTile.xaml#L12
       // Should use 'AcrylicInAppFillColorDefaultBrush', blocked on https://github.com/microsoft/react-native-windows/issues/8861
       // (The acrylic does work, but does not update when the theme changes)
-      backgroundColor: isHovered
-        ? '#f3f3f3'
-        : '#f9f9f9',
+      backgroundColor: PlatformColor('Background'),
       borderColor: isHovered
         ? '#b6b9bc'
         : '#b7babd',


### PR DESCRIPTION
## Description
Fixes instances of text and background color incorrectly/not using PlatformColor values on New Architecture.
### Why

Resolves #537 
Resolves #538

### What

Change text and background color values.

## Screenshots

Dark mode:
![image](https://github.com/user-attachments/assets/ac621b97-452d-4498-840d-fab30f275065)

Aquatic contrast mode:
![image](https://github.com/user-attachments/assets/c448c13a-b4ae-4d7d-b1ca-c6e18a6349a4)